### PR TITLE
chore: exclude terraform lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# .terraform.lock.hcl files
+.terraform.lock.hcl


### PR DESCRIPTION
- Exclude `.terraform.lock.hcl` from Git